### PR TITLE
Add remote for ggtree

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,6 +3,7 @@ Title: A Collection of R Functions and Snippets I Often Use.
 Version: 0.0.0.9000
 Authors@R: person("Thomas", "Hackl", email = "thackl@lim4.de", role = c("aut", "cre"))
 Description: This R package is a collection function and snippets I routinely use. Many are very basic, others just haven't found a better place yet...
+Remotes: bioc::release/ggtree
 Depends: R (>= 3.4.4)
 Imports:
     magrittr,


### PR DESCRIPTION
When installing dependencies with the `remotes` package only dependencies on CRAN are automatically installed. Other remotes (bioconductor in this case) need to be explicitly stated.
See: https://github.com/r-lib/remotes#dependencies

The `remotes` package is commonly used in github actions.